### PR TITLE
Avoid failure in one event to break all event import

### DIFF
--- a/src/otx_misp/__init__.py
+++ b/src/otx_misp/__init__.py
@@ -133,7 +133,17 @@ def create_events(pulse_or_list, author=False, server=False, key=False, misp=Fal
         misp.discovered_tags = tags
 
     if isinstance(pulse_or_list, (list, tuple)) or inspect.isgenerator(pulse_or_list):
-        return [create_events(pulse, author=author, server=server, key=key, misp=misp, distribution=distribution,
+        result_event = []
+        for pulse in pulse_or_list:
+          try:
+            result = create_events(pulse, author=author, server=server, key=key, misp=misp, distribution=distribution,
+                              threat_level=threat_level, analysis=analysis, publish=publish, tlp=tlp, to_ids=to_ids)
+            result_event.append(result)
+          except:
+            pass
+          
+        return result_event
+        #return [create_events(pulse, author=author, server=server, key=key, misp=misp, distribution=distribution,
                               threat_level=threat_level, analysis=analysis, publish=publish, tlp=tlp, to_ids=to_ids)
                 for pulse in pulse_or_list]
     pulse = pulse_or_list


### PR DESCRIPTION
When importing a list of events (using the --timestamp option) and one of the events fails the import is stopped and no more events are imported. This change encloses every import in a try catch in order to be able to continue the import of the rest of the events when a single event import fails.